### PR TITLE
fix: Correct CI workflow working directory

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,7 @@ jobs:
         dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
+      working-directory: PurrfectBlog
     - name: Build
       run: dotnet build --no-restore
     - name: Test


### PR DESCRIPTION
This commit fixes an issue where the GitHub Actions workflow was unable to locate the solution file. The 'dotnet restore' command was looking for a solution in the root directory, but the project is located in a subdirectory. To fix this I added a working directory parameter to the workflow which should correctly point to the workflow file