### PR TITLE
feat: create dotnet.yaml to build project on push

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,23 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Restore dependencies
+      run: nuget restore PurrfectBlog.sln
+    - name: Build
+      run: msbuild PurrfectBlog.sln /p:Configuration=Release
+    - name: Test
+      run: vstest.console.exe PurrfectBlog.Tests\bin\Release\PurrfectBlog.Tests.dll


### PR DESCRIPTION
This is intended to add a workflow that runs automatically when items are pushed to main or a PR is pointed to main. This workflow will run and ensure it builds correctly.