### PR TITLE
feat(post): Implement functionality for creating posts

### DIFF
--- a/PurrfectBlog/.gitignore
+++ b/PurrfectBlog/.gitignore
@@ -16,3 +16,7 @@ x86/
 # Packages
 *.nupkg
 [Pp]ackages/
+
+# Local database files
+/PurrfectBlog/App_Data/*.mdf
+/PurrfectBlog/App_Data/*.ldf

--- a/PurrfectBlog/PurrfectBlog/Content/Site.css
+++ b/PurrfectBlog/PurrfectBlog/Content/Site.css
@@ -11,10 +11,3 @@
 .dl-horizontal dt {
     white-space: normal;
 }
-
-/* Set width on the form input elements since they're 100% wide by default */
-input,
-select,
-textarea {
-    max-width: 280px;
-}

--- a/PurrfectBlog/PurrfectBlog/Controllers/AuthController.cs
+++ b/PurrfectBlog/PurrfectBlog/Controllers/AuthController.cs
@@ -66,13 +66,13 @@ namespace PurrfectBlog.Controllers
 
                 if (author == null)
                 {
-                    ModelState.AddModelError("", "Username is invalid.");
+                    ModelState.AddModelError("UserName", "Username is invalid.");
                     return View(model);
                 }
 
                 if (!System.Web.Helpers.Crypto.VerifyHashedPassword(author.HashedPassword, model.Password))
                 {
-                    ModelState.AddModelError("", "Password is invalid.");
+                    ModelState.AddModelError("Password", "Password is invalid.");
                     return View(model);
                 }
 

--- a/PurrfectBlog/PurrfectBlog/Controllers/AuthController.cs
+++ b/PurrfectBlog/PurrfectBlog/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 ﻿using PurrfectBlog.Models;
 using PurrfectBlog.Models.ViewModels;
+using System;
 using System.Linq;
 using System.Web.Mvc;
 using System.Web.Security;
@@ -24,9 +25,9 @@ namespace PurrfectBlog.Controllers
                 return View(model);
             }
 
-            using ( var db = new BlogDbContext())
+            using (var db = new BlogDbContext())
             {
-                if (db.Authors.Any(author => author.UserName.ToLower() == model.UserName.ToLower()))
+                if (db.Authors.Any(author => author.UserName.Equals(model.UserName, StringComparison.OrdinalIgnoreCase)))
                 {
                     ModelState.AddModelError("UserName", "Sorry, this username is pawlready taken!");
                     return View(model);
@@ -61,9 +62,9 @@ namespace PurrfectBlog.Controllers
 
             using (var db = new BlogDbContext())
             {
-                var author = db.Authors.FirstOrDefault(a => a.UserName.ToLower() == model.UserName.ToLower());
+                var author = db.Authors.FirstOrDefault(a => a.UserName.Equals(model.UserName, StringComparison.OrdinalIgnoreCase));
 
-                if (author == null )
+                if (author == null)
                 {
                     ModelState.AddModelError("", "Username is invalid.");
                     return View(model);

--- a/PurrfectBlog/PurrfectBlog/Controllers/PostController.cs
+++ b/PurrfectBlog/PurrfectBlog/Controllers/PostController.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using PurrfectBlog.Models;
 using System.Web.Mvc;
+using System.Linq;
 
 namespace PurrfectBlog.Controllers
 {
+    [Authorize]
     public class PostController : Controller
     {
         private readonly BlogDbContext _context = new BlogDbContext();
@@ -18,15 +20,37 @@ namespace PurrfectBlog.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Create(Post post)
         {
+
             if (ModelState.IsValid)
             {
-                post.CreationDate = DateTime.UtcNow;
-                _context.Posts.Add(post);
-                _context.SaveChanges();
+                var username = User.Identity.Name;
+                var author = _context.Authors.FirstOrDefault(a => a.UserName == username);
 
-                return RedirectToAction("Index", "Home");
+                if (author != null)
+                {
+                    post.AuthorId = author.Id;
+                    post.CreationDate = DateTime.Now;
+
+                    _context.Posts.Add(post);
+                    _context.SaveChanges();
+                    // implement redirect to the post pages
+                }
+                else
+                {
+                    ModelState.AddModelError("", "Cannot Ffind an author for the current user");
+                }
+               
             }
             return View(post);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _context.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/PurrfectBlog/PurrfectBlog/Controllers/PostController.cs
+++ b/PurrfectBlog/PurrfectBlog/Controllers/PostController.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using PurrfectBlog.Models;
+using System.Web.Mvc;
+
+namespace PurrfectBlog.Controllers
+{
+    public class PostController : Controller
+    {
+        private readonly BlogDbContext _context = new BlogDbContext();
+        // GET: Post/Create
+        public ActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: Post/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Create(Post post)
+        {
+            if (ModelState.IsValid)
+            {
+                post.CreationDate = DateTime.UtcNow;
+                _context.Posts.Add(post);
+                _context.SaveChanges();
+
+                return RedirectToAction("Index", "Home");
+            }
+            return View(post);
+        }
+    }
+}

--- a/PurrfectBlog/PurrfectBlog/Controllers/PostController.cs
+++ b/PurrfectBlog/PurrfectBlog/Controllers/PostController.cs
@@ -9,13 +9,11 @@ namespace PurrfectBlog.Controllers
     public class PostController : Controller
     {
         private readonly BlogDbContext _context = new BlogDbContext();
-        // GET: Post/Create
         public ActionResult Create()
         {
             return View();
         }
 
-        // POST: Post/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
         public ActionResult Create(Post post)
@@ -24,7 +22,7 @@ namespace PurrfectBlog.Controllers
             if (ModelState.IsValid)
             {
                 var username = User.Identity.Name;
-                var author = _context.Authors.FirstOrDefault(a => a.UserName == username);
+                var author = _context.Authors.FirstOrDefault(a => a.UserName.Equals(username, StringComparison.OrdinalIgnoreCase));
 
                 if (author != null)
                 {
@@ -33,11 +31,12 @@ namespace PurrfectBlog.Controllers
 
                     _context.Posts.Add(post);
                     _context.SaveChanges();
-                    // implement redirect to the post pages
+                    //TODO: implement redirect to the post details page (likely in next step)
+                    return RedirectToAction("Index", "Home");
                 }
                 else
                 {
-                    ModelState.AddModelError("", "Cannot Ffind an author for the current user");
+                    ModelState.AddModelError("", "Cannot find an author for the current user");
                 }
                
             }

--- a/PurrfectBlog/PurrfectBlog/Global.asax.cs
+++ b/PurrfectBlog/PurrfectBlog/Global.asax.cs
@@ -1,9 +1,5 @@
 ﻿using PurrfectBlog.Models;
-using System;
-using System.Collections.Generic;
 using System.Data.Entity;
-using System.Linq;
-using System.Web;
 using System.Web.Mvc;
 using System.Web.Optimization;
 using System.Web.Routing;
@@ -18,7 +14,12 @@ namespace PurrfectBlog
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
-            Database.SetInitializer(new Models.BlogDbInitializer());
+            Database.SetInitializer(new BlogDbInitializer());
+
+            using (var context = new BlogDbContext())
+            {
+                context.Database.Initialize(force: true);
+            }
         }
     }
 }

--- a/PurrfectBlog/PurrfectBlog/Global.asax.cs
+++ b/PurrfectBlog/PurrfectBlog/Global.asax.cs
@@ -15,11 +15,6 @@ namespace PurrfectBlog
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
             Database.SetInitializer(new BlogDbInitializer());
-
-            using (var context = new BlogDbContext())
-            {
-                context.Database.Initialize(force: true);
-            }
         }
     }
 }

--- a/PurrfectBlog/PurrfectBlog/Models/BlogDbContext.cs
+++ b/PurrfectBlog/PurrfectBlog/Models/BlogDbContext.cs
@@ -6,5 +6,6 @@ namespace PurrfectBlog.Models
     {
         public BlogDbContext() : base("DefaultConnection") { }
         public DbSet<Author> Authors { get; set; }
+        public DbSet<Post> Posts { get; set; }
     }
 }

--- a/PurrfectBlog/PurrfectBlog/Models/BlogDbInitializer.cs
+++ b/PurrfectBlog/PurrfectBlog/Models/BlogDbInitializer.cs
@@ -1,11 +1,12 @@
 ﻿using System.Data.Entity;
 using System.Collections.Generic;
 using System.Web.Helpers;
+using System;
 
 namespace PurrfectBlog.Models
 {
     // We are using DropCreateDatabaseIfModelChanges for simplicity of development, will update to migrations later
-    public class BlogDbInitializer : DropCreateDatabaseIfModelChanges<BlogDbContext>
+    public class BlogDbInitializer : DropCreateDatabaseAlways<BlogDbContext>
     {
         protected override void Seed(BlogDbContext context)
         {
@@ -17,6 +18,28 @@ namespace PurrfectBlog.Models
             };
             authors.ForEach(a => context.Authors.Add(a));
             context.SaveChanges();
+
+            var posts = new List<Post>
+            {
+                new Post
+                {
+                    Title = "Hey guys, first time poster! Just found a kitten, what should I feed her" ,
+                    Content = "Right meow she's sitting on the couch and cleaning herself. She's a little thing... maybe 5 pounds at most! Found her outside and not sure what to feed her as I can't go to the store for catfood right now.",
+                    CreationDate = DateTime.Now,
+                    AuthorId = authors[0].Id
+                },
+                new Post
+                {
+                    Title = "I'm allergic but still want a cat, what breed makes sense?",
+                    Content = "As the title states, I'm actually allergic to cats! But I just find them SOOO cute!! I know there are hypoallergenic breeds, but was wondering if someone could point me to what breeds would make the most sense for me. Thanks!",
+                    CreationDate = DateTime.Now,
+                    AuthorId = authors[1].Id
+                }
+            };
+            posts.ForEach(p => context.Posts.Add(p));
+            context.SaveChanges();
+
+            base.Seed(context);
         }
     }
 }

--- a/PurrfectBlog/PurrfectBlog/Models/BlogDbInitializer.cs
+++ b/PurrfectBlog/PurrfectBlog/Models/BlogDbInitializer.cs
@@ -6,7 +6,7 @@ using System;
 namespace PurrfectBlog.Models
 {
     // We are using DropCreateDatabaseIfModelChanges for simplicity of development, will update to migrations later
-    public class BlogDbInitializer : DropCreateDatabaseAlways<BlogDbContext>
+    public class BlogDbInitializer : DropCreateDatabaseIfModelChanges<BlogDbContext>
     {
         protected override void Seed(BlogDbContext context)
         {

--- a/PurrfectBlog/PurrfectBlog/Models/BlogDbInitializer.cs
+++ b/PurrfectBlog/PurrfectBlog/Models/BlogDbInitializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Web.Helpers;
 using System;
+using System.Linq;
 
 namespace PurrfectBlog.Models
 {
@@ -10,6 +11,12 @@ namespace PurrfectBlog.Models
     {
         protected override void Seed(BlogDbContext context)
         {
+
+            if (context.Authors.Any())
+            {
+                return;
+            }
+
             var authors = new List<Author>
             {
                 new Author { UserName = "Shakespeare", HashedPassword = Crypto.HashPassword("ToBeOrNotToBe123!") },

--- a/PurrfectBlog/PurrfectBlog/Models/Post.cs
+++ b/PurrfectBlog/PurrfectBlog/Models/Post.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace PurrfectBlog.Models
+{
+    public class Post
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required(ErrorMessage = "All posts require a title between 20 and 200 characters.")]
+        [StringLength(200, MinimumLength = 20, ErrorMessage = "Title must be between 20 and 200 characters.")]
+        public string Title { get; set; }
+
+        [Required(ErrorMessage = "Content body is required.")]
+        [StringLength(500, MinimumLength = 20, ErrorMessage = "Post content must be between 20 and 500 characters.")]
+        public string Content { get; set; }
+
+        public DateTime CreationDate { get; set; }
+
+        public int AuthorId { get; set; }
+
+        [ForeignKey("AuthorId")]
+        public virtual Author Author { get; set; }
+    }
+}

--- a/PurrfectBlog/PurrfectBlog/PurrfectBlog.csproj
+++ b/PurrfectBlog/PurrfectBlog/PurrfectBlog.csproj
@@ -130,12 +130,14 @@
     <Compile Include="Controllers\AuthController.cs" />
     <Compile Include="Controllers\DashboardController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\PostController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Models\Author.cs" />
     <Compile Include="Models\BlogDbContext.cs" />
     <Compile Include="Models\BlogDbInitializer.cs" />
+    <Compile Include="Models\Post.cs" />
     <Compile Include="Models\ViewModels\LoginViewModel.cs" />
     <Compile Include="Models\ViewModels\RegisterViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -194,6 +196,7 @@
     <Content Include="Views\Auth\Register.cshtml" />
     <Content Include="Views\Auth\Login.cshtml" />
     <Content Include="Views\Dashboard\Index.cshtml" />
+    <Content Include="Views\Post\Create.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/PurrfectBlog/PurrfectBlog/Views/Auth/Login.cshtml
+++ b/PurrfectBlog/PurrfectBlog/Views/Auth/Login.cshtml
@@ -7,7 +7,7 @@
 <h2>Log in To your Author Dashboard!</h2>
 
 
-<div class="container mx-w-md bg-light rounded-lg my-4">
+<div class="container mx-w-md bg-light rounded-lg my-8">
     @using (Html.BeginForm("Login", "Auth", FormMethod.Post, new { @class = "space-y-4" }))
     {
         @Html.AntiForgeryToken()

--- a/PurrfectBlog/PurrfectBlog/Views/Auth/Login.cshtml
+++ b/PurrfectBlog/PurrfectBlog/Views/Auth/Login.cshtml
@@ -4,27 +4,34 @@
     ViewBag.Title = "Login";
 }
 
-<h2>Log in To your Author Dashboard!</h2>
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <h2 class="card-title text-center">Log In</h2>
+                <hr />
+                @using (Html.BeginForm("Login", "Auth", FormMethod.Post))
+                {
+                    @Html.AntiForgeryToken()
+                    @Html.ValidationSummary(true, "", new { @class = "text-danger" })
 
+                    <div class="form-group mb-3">
+                        @Html.LabelFor(a => a.UserName)
+                        @Html.TextBoxFor(a => a.UserName, new { @class = "form-control" })
+                        @Html.ValidationMessageFor(a => a.UserName, "", new { @class = "text-danger" })
+                    </div>
 
-<div class="container mx-w-md bg-light rounded-lg my-8">
-    @using (Html.BeginForm("Login", "Auth", FormMethod.Post, new { @class = "space-y-4" }))
-    {
-        @Html.AntiForgeryToken()
-        @Html.ValidationSummary(true, "", new { @class = "text-danger" })
+                    <div class="form-group mb-3">
+                        @Html.LabelFor(a => a.Password)
+                        @Html.PasswordFor(a => a.Password, new { @class = "form-control" })
+                        @Html.ValidationMessageFor(a => a.Password, "", new { @class = "text-danger" })
+                    </div>
 
-        <div class="form-group">
-            @Html.LabelFor(a => a.UserName)
-            @Html.TextBoxFor(a => a.UserName, new { @class = "form-control" })
-            @Html.ValidationMessageFor(a => a.UserName, "", new { @class = "text-danger" })
+                    <div class="form-group text-center mt-4">
+                        <button type="submit" class="btn btn-primary">Log In!</button>
+                    </div>
+                }
+            </div>
         </div>
-
-        <div class="form-group">
-            @Html.LabelFor(a => a.Password)
-            @Html.PasswordFor(a => a.Password, new { @class = "form-control" })
-            @Html.ValidationMessageFor(a => a.Password, "", new { @class = "text-danger" })
-        </div>
-
-        <button type="submit" class="btn btn-primary my-2">Log In!</button>
-    }
+    </div>
 </div>

--- a/PurrfectBlog/PurrfectBlog/Views/Post/Create.cshtml
+++ b/PurrfectBlog/PurrfectBlog/Views/Post/Create.cshtml
@@ -1,0 +1,47 @@
+﻿@model PurrfectBlog.Models.Post
+
+@{
+    ViewBag.Title = "Create New Post";
+}
+
+<div class="row justify-content-center">
+    <div class="col-md-8">
+        <div class="card">
+            <div class="card-body">
+                <h2 class="card-title text-center">@ViewBag.Title</h2>
+                <h4 class="text-center text-muted">Share your purrfect story!</h4>
+                <hr />
+
+                @using (Html.BeginForm())
+                {
+                    @Html.AntiForgeryToken()
+
+                    @Html.ValidationSummary(true, "", new { @class = "text-danger" })
+
+                    <div class="form-group mb-3">
+                        @Html.LabelFor(model => model.Title, htmlAttributes: new { @class = "control-label" })
+                        @Html.EditorFor(model => model.Title, new { htmlAttributes = new { @class = "form-control" } })
+                        @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                    </div>
+
+                    <div class="form-group mb-3">
+                        @Html.LabelFor(model => model.Content, htmlAttributes: new { @class = "control-label" })
+                        @Html.TextAreaFor(model => model.Content, 10, 40, new { @class = "form-control" })
+                        @Html.ValidationMessageFor(model => model.Content, "", new { @class = "text-danger" })
+                    </div>
+
+                    <div class="form-group text-center">
+                        <input type="submit" value="Create" class="btn btn-primary" />
+                    </div>
+                }
+            </div>
+        </div>
+        <div class="text-center mt-3">
+            @Html.ActionLink("Back to List", "Index", "Home")
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @Scripts.Render("~/bundles/jqueryval")
+}

--- a/PurrfectBlog/PurrfectBlog/Views/Post/Create.cshtml
+++ b/PurrfectBlog/PurrfectBlog/Views/Post/Create.cshtml
@@ -15,23 +15,26 @@
                 @using (Html.BeginForm())
                 {
                     @Html.AntiForgeryToken()
-
                     @Html.ValidationSummary(true, "", new { @class = "text-danger" })
 
-                    <div class="form-group mb-3">
-                        @Html.LabelFor(model => model.Title, htmlAttributes: new { @class = "control-label" })
-                        @Html.EditorFor(model => model.Title, new { htmlAttributes = new { @class = "form-control" } })
-                        @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                    </div>
+                    <div class="row justify-content-center">
+                        <div class="col-md-7">
+                            <div class="form-group mb-3">
+                                @Html.LabelFor(model => model.Title, htmlAttributes: new { @class = "control-label" })
+                                @Html.EditorFor(model => model.Title, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                            </div>
 
-                    <div class="form-group mb-3">
-                        @Html.LabelFor(model => model.Content, htmlAttributes: new { @class = "control-label" })
-                        @Html.TextAreaFor(model => model.Content, 10, 40, new { @class = "form-control" })
-                        @Html.ValidationMessageFor(model => model.Content, "", new { @class = "text-danger" })
-                    </div>
+                            <div class="form-group mb-3">
+                                @Html.LabelFor(model => model.Content, htmlAttributes: new { @class = "control-label" })
+                                @Html.TextAreaFor(model => model.Content, 10, 40, new { @class = "form-control" })
+                                @Html.ValidationMessageFor(model => model.Content, "", new { @class = "text-danger" })
+                            </div>
 
-                    <div class="form-group text-center">
-                        <input type="submit" value="Create" class="btn btn-primary" />
+                            <div class="form-group text-center mt-4">
+                                <input type="submit" value="Create" class="btn btn-primary" />
+                            </div>
+                        </div>
                     </div>
                 }
             </div>

--- a/PurrfectBlog/PurrfectBlog/Views/Shared/_Layout.cshtml
+++ b/PurrfectBlog/PurrfectBlog/Views/Shared/_Layout.cshtml
@@ -25,6 +25,7 @@
                     @if (User.Identity.IsAuthenticated)
                     {
                         <li>@Html.ActionLink("Dashboard", "Index", "Dashboard", new { area = "" }, new { @class = "nav-link" })</li>
+                        <li>@Html.ActionLink("Create Post", "Create", "Post", new { area = ""}, new { @class = "nav-link "})</li>
                         <li>@Html.ActionLink("Log out", "Logout", "Auth", new { area = "" }, new { @class = "nav-link" })</li>
                     }
                     else

--- a/PurrfectBlog/PurrfectBlog/Web.config
+++ b/PurrfectBlog/PurrfectBlog/Web.config
@@ -11,7 +11,7 @@
   <connectionStrings>
 	<add name="DefaultConnection"
 		providerName="System.Data.SqlClient"
-		connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=PurrfectBlog;Integrated Security=True;"/>
+	    connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=PurrfectBlog;Integrated Security=True;AttachDbFilename=|DataDirectory|\PurrfectBlog.mdf" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />


### PR DESCRIPTION
Introduces the functionality for creating new blog posts. Users should be able, if authenticated, toa write and save a post to the database which will persist even after a system restart.


#### **Key Changes:**

*   **Data:**
    *   Created Post model with validation for the Title and Content.
    *   Updated BlogDbContext to include Posts.

*   **Controllers:**
    *   Created the postController with Create actions to display the form (GET) and process it (POST).
    *   Secured to ensure only logged-in users can create posts.

*   **Configuration & Bug Fixes:**
    *   Updated connection string to point to the DataDirectory.
    *   Updated gitignore to ignore the database files.
    *   Refactored AuthController to use case-insensitive username comparisons.

*   **Views & UI:**
    *   Created the Create.cshtml view.
    *   Added a "Create Post" link to the main layout for authenticated users.
    *   Refactored Login.cshtml to use a similar card-based layout for consistency.